### PR TITLE
修改 Login.py 部分内容

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,11 @@
 name: 'housamoAutoLogin'
  
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0  0,7,15,23 * * *'
   watch:
     types: [started]
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0  0,7,15,23 * * *'
   watch:
     types: [started]
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     - cron: '0  0,7,15,23 * * *'
   watch:
     types: [started]
+  workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,5 @@ jobs:
       run: pip install requests
     - name: Read anth_key & Login  #读取账号并登录
       env: 
-        auth_key_dandan: ${{ secrets.AUTH_KEY_DANDAN }}   # secrets 提供
-        auth_key_pipi: ${{ secrets.AUTH_KEY_PIPI }}
+        auth_key_gofly: ${{ secrets.AUTH_KEY_GOFLY }}   # secrets 提供
       run: python Login.py

--- a/Login.py
+++ b/Login.py
@@ -1,49 +1,48 @@
 import requests
 import os
 
-header_get = {
+HEADER_GET = {
     'X-Unity-Version': '2018.4.7f1',
     'GCA': 'X',
     'Content-Type': 'application/x-www-form-urlencoded',
     'CDNDataVersion': '6310',
-    'User-Agent': 'HousamoAPI/4.10.2 Android OS 6.0.1 / API-23 (V417IR/eng.luoweiqiao.20201016.150344) Netease MuMu',
+    'User-Agent': 'HousamoAPI/4.11.0 Android OS 6.0.1 / API-23 (V417IR/eng.luoweiqiao.20201016.150344)',
     'Response-Crypt': 'enable',
     'Host': 'elb.housamo.jp',
     'Connection': 'Keep-Alive',
     'Accept-Encoding': 'gzip',
 }
 
-header_post = {
+HEADER_POST = {
     'Expect': '100-continue',
     'X-Unity-Version': '2018.4.7f1',
     'GCA': 'X',
     'Content-Type': 'application/x-www-form-urlencoded',
     'CDNDataVersion': '6310',
-    'User-Agent': 'HousamoAPI/4.10.2 Android OS 6.0.1 / API-23 (V417IR/eng.luoweiqiao.20201016.150344) Netease MuMu',
+    'User-Agent': 'HousamoAPI/4.11.0 Android OS 6.0.1 / API-23 (V417IR/eng.luoweiqiao.20201016.150344)',
     'Response-Crypt': 'enable',
-    'Content-Length': '57',
     'Host': 'elb.housamo.jp',
     'Connection': 'Keep-Alive',
     'Accept-Encoding': 'gzip'
 }
 
 
-def Login(auth_key):
+def login_by_authkey(auth_key):
     data = {'auth_key': auth_key}
 
     url1 = 'http://elb.housamo.jp/account/login'
-    url2 = 'https://elb.housamo.jp/user/status?auth_key=' + auth_key
-    url3 = 'http://elb.housamo.jp/mypage/status?auth_key=' + auth_key
+    url2 = f'https://elb.housamo.jp/user/status?auth_key={auth_key}'
+    url3 = f'http://elb.housamo.jp/mypage/status?auth_key={auth_key}'
 
-    res1 = requests.post(url1, headers = header_post, data = data)
-    res2 = requests.get(url2, headers = header_get)
-    res3 = requests.get(url3, headers = header_get)
+    res1 = requests.post(url1, headers = HEADER_POST, data = data)
+    res2 = requests.get(url2, headers = HEADER_GET)
+    res3 = requests.get(url3, headers = HEADER_GET)
 
-    print(res1.content, '\n')
-    print(res2.content, '\n')
-    print(res3.content, '\n')
+    print(res1.text, '\n')
+    print(res2.text, '\n')
+    print(res3.text, '\n')
 
-auth_keys = [os.environ["auth_key_dandan"], os.environ["auth_key_pipi"]]
-
-for auth_key in auth_keys:
-    Login(auth_key) 
+if __name__ == '__main__':
+    AUTH_KEYS = (os.environ["auth_key_dandan"], os.environ["auth_key_pipi"])
+    for auth_key in AUTH_KEYS:
+        login_by_authkey(auth_key) 

--- a/Login.py
+++ b/Login.py
@@ -6,7 +6,7 @@ header_get = {
     'GCA': 'X',
     'Content-Type': 'application/x-www-form-urlencoded',
     'CDNDataVersion': '6310',
-    'User-Agent': 'HousamoAPI/4.10.2 Android OS 6.0.1 / API-23 (V417IR/eng.luoweiqiao.20201016.150344) Netease MuMu',
+    'User-Agent': 'HousamoAPI/4.11.0 Android OS 6.0.1 / API-23 (V417IR/eng.luoweiqiao.20201016.150344) Netease MuMu',
     'Response-Crypt': 'enable',
     'Host': 'elb.housamo.jp',
     'Connection': 'Keep-Alive',
@@ -19,7 +19,7 @@ header_post = {
     'GCA': 'X',
     'Content-Type': 'application/x-www-form-urlencoded',
     'CDNDataVersion': '6310',
-    'User-Agent': 'HousamoAPI/4.10.2 Android OS 6.0.1 / API-23 (V417IR/eng.luoweiqiao.20201016.150344) Netease MuMu',
+    'User-Agent': 'HousamoAPI/4.11.0 Android OS 6.0.1 / API-23 (V417IR/eng.luoweiqiao.20201016.150344) Netease MuMu',
     'Response-Crypt': 'enable',
     'Content-Length': '57',
     'Host': 'elb.housamo.jp',
@@ -43,7 +43,7 @@ def Login(auth_key):
     print(res2.content, '\n')
     print(res3.content, '\n')
 
-auth_keys = [os.environ["auth_key_dandan"], os.environ["auth_key_pipi"]]
+auth_keys = (os.environ["auth_key_gofly"],)
 
 for auth_key in auth_keys:
     Login(auth_key) 


### PR DESCRIPTION
1. URL 改为格式化字符串，更符合编码规范
2. 更新请求 UA 中的 HousamoAPI 值为 4.11.0（版本更新）
3. 移除请求 UA 无用内容
4. 获取 Responge 的 content 改为获取 text 值
5. 改 auth_keys 为 AUTH_KEYS（常亮），并将其类型改为元组
6. 加入 if \_\_name\_\_ == '\_\_main\_\_':，更符合规范，并将 AUTH_KEYS 移入其中
7. 将函数 Login 改为 login_by_authkey，更符合命名规范
8. 将不变的字典 header_get 与 header_post 分别改为 HEADER_GET 与 HEADER_POST